### PR TITLE
First pass at adding SEMIA features

### DIFF
--- a/dvt/annotate/__init__.py
+++ b/dvt/annotate/__init__.py
@@ -8,5 +8,7 @@ from . import face
 from . import png
 from . import object 
 from . import meta 
+from . import cielab
+from . import clutter
 
 __version__ = "0.1.0"

--- a/dvt/annotate/cielab.py
+++ b/dvt/annotate/cielab.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Annotators to extract CIELAB color histograms.
+"""
+
+import numpy as np
+import cv2
+from scipy.cluster.vq import kmeans
+
+from .core import FrameAnnotator
+
+class CIElabAnnotator(FrameAnnotator):
+    """Annotator for constructing a color histogram and extracting the dominant
+    colours for an image in CIELAB colorspace.
+
+    The annotator will return a histogram describing the color distribution 
+    of an image, and a list of the most dominant colors.
+
+    Attributes:
+        freq (int): How often to perform the embedding. For example, setting
+            the frequency to 2 will computer every other frame in the batch.
+        num_buckets (tuple): A tuple of three numbers giving the maximum number
+            of buckets in each color channel, Lightness, A, B. These
+            should each be divisible by 256. Default is (16, 16, 16).
+        num_dominant (int): Number of dominant colors to extract. Default is 5.
+    """
+
+    name = "cielab"
+
+    def __init__(self, freq=1, num_buckets=(16, 16, 16), num_dominant=5):
+
+        self.freq = freq
+        self.num_buckets = num_buckets
+        self.num_dominant = num_dominant
+        super().__init__()
+
+    def annotate(self, batch):
+        """Annotate the batch of frames with the cielab annotator.
+
+        Args:
+            batch (FrameBatch): A batch of images to annotate.
+
+        Returns:
+            A list of dictionaries containing the video name, frame, the 
+            CIELAB histogram of length (num_buckets[0] * num_buckets[1] *
+            num_buckets[2]), and an array of dominant colors of shape
+            (num_dominant, 3).
+        """
+
+        # run the color analysis on each frame
+        hgrams = []
+        dominant = []
+        for fnum in range(0, batch.bsize, self.freq):
+            img_lab = cv2.cvtColor(batch.img[fnum, :, :, :], cv2.COLOR_RGB2LAB)
+
+            hgrams += [_get_cielab_histogram(img_lab,
+                       self.num_buckets)]
+            if self.num_dominant > 0:
+                dominant += [_get_cielab_dominant(img_lab, self.num_dominant)]
+
+        obj = {'cielab': np.vstack(hgrams)}
+
+        if self.num_dominant > 0:
+            obj['dominant_colors'] = np.stack(dominant)
+
+        # Add video and frame metadata
+        frames = range(0, batch.bsize, self.freq)
+        obj["video"] = [batch.vname] * len(frames)
+        obj["frame"] = np.array(batch.get_frame_names())[list(frames)]
+
+        return [obj]
+
+
+def _get_cielab_histogram(img, num_buckets):
+
+    return cv2.calcHist([img], [0, 1, 2], 
+                None, num_buckets, [0, 256, 0, 256, 0, 256]).reshape(-1)
+
+
+def _get_cielab_dominant(img, num_dominant):
+    img_flat = img.reshape(-1, 3).astype(np.float32)
+    
+    # increasing iter would give 'better' clustering, at the cost of speed
+    dominant_colors, _ = kmeans(img_flat, num_dominant, iter=5)
+
+    return dominant_colors.astype(np.uint8)

--- a/dvt/annotate/clutter.py
+++ b/dvt/annotate/clutter.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Annotators to extract clutter or visual complexity values.
+"""
+
+import numpy as np
+import cv2
+import pyrtools as pt
+
+from .core import FrameAnnotator
+
+class ClutterAnnotator(FrameAnnotator):
+    """Annotator for extracting the clutter or visual complexity value from a
+    frame. The clutter value is calculated based on the Subband Entropy
+    algorithm proposed by Ruth Rosenholtz, Yuanzhen Li, and Lisa Nakano. in
+    "Measuring Visual Clutter". Journal of Vision, 7(2), 2007. 
+
+    The annotator will return a a single value per frame, describing its
+    clutter value.
+
+    Attributes:
+        freq (int): How often to perform the embedding. For example, setting
+            the frequency to 2 will computer every other frame in the batch.
+    """
+
+    name = "clutter"
+
+    def __init__(self, freq=1):
+
+        self.freq = freq
+        super().__init__()
+
+    def annotate(self, batch):
+        """Annotate the batch of frames with the cielab annotator.
+
+        Args:
+            batch (FrameBatch): A batch of images to annotate.
+
+        Returns:
+            A list of dictionaries containing the video name, frame, and the
+            clutter value extracted from the frame.
+        """
+
+        # run the clutter analysis on each frame
+        clutter_val = []
+        for fnum in range(0, batch.bsize, self.freq):
+            clutter_val += [_get_clutter(batch.img[fnum, :, :, :])]
+
+        obj = {'clutter': np.vstack(clutter_val)}
+
+        # Add video and frame metadata
+        frames = range(0, batch.bsize, self.freq)
+        obj["video"] = [batch.vname] * len(frames)
+        obj["frame"] = np.array(batch.get_frame_names())[list(frames)]
+
+        return [obj]
+
+
+def _entropy(samples):
+    nsamples = samples.size
+    nbins = int(np.ceil(np.sqrt(nsamples)))
+
+    bincount,_ = np.histogram(samples, nbins)
+    H = bincount[ np.where(bincount > 0) ]
+    H = H / float(sum(H))
+
+    return -sum(H * np.log2(H))
+
+
+def _band_entropy(img, wlevels, wor):
+    sfpyr = pt.pyramids.SteerablePyramidFreq(img, wlevels, wor-1) 
+
+    en_band = np.zeros((sfpyr.num_scales, sfpyr.num_orientations))
+
+    for i in range(sfpyr.num_scales):
+        for b in range(sfpyr.num_orientations):
+            band = sfpyr.pyr_coeffs[(i, b)]
+            en_band[i, b] = _entropy(np.ravel(band))
+
+    return en_band
+
+
+def _get_clutter(img, wlevels=3, wght_chrom=0.0625):
+    if len(img.shape) == 3:
+        ht, wth, dchrom = img.shape
+    else:
+        ht, wth = img.shape
+        dchrom = 1
+
+    if dchrom == 4:
+        img = img[:,:,:3]
+        dchrom = 3
+
+    if dchrom == 3:
+        img = cv2.cvtColor(img, cv2.COLOR_RGB2LAB)
+
+    wor = 4
+    if dchrom == 1:
+        L = img
+    else:
+        L = img[:,:,0]
+    en_band = _band_entropy(L, wlevels, wor)
+    clutter_se = np.mean(en_band)
+
+    if dchrom == 1: return clutter_se
+
+    for i in range(1,3): 
+        chrom = img[:,:,i]
+        if (np.max(chrom)-np.min(chrom)) < 0.008:
+            chrom = np.zeros(chrom.shape)
+        en_band = _band_entropy(chrom, wlevels, wor)
+        clutter_se += wght_chrom*np.mean(en_band)
+
+    clutter_se /= (1+2*wght_chrom)
+    return clutter_se

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest-cov
 pytest-pep8
 codecov
 cmake
+pyrtools


### PR DESCRIPTION
In converting my enthusiasm from DH2019 into something productive I took a first crack at adding two of the features we use in [SEMIA ](https://sensorymovingimagearchive.humanities.uva.nl/) to dvt. Specifically, the colour feature and the clutter feature.

For the colour feature we work in CIELAB colourspace, and extract a histogram, and the N dominant colours. Currently, these are in a single annotator, but I can imagine it might be worthwhile to separate them into different annotators. For the histogram we've noticed its beneficial to treat the values as tuples, and count the LAB values jointly. This is what the opencv function does by default, so I've essentially just added a wrapper for that function. The dominant colours is based on the KMeans clustering result over the LAB colours.

The other is the visual complexity or clutter feature, which requires an additional dependency: [pyrTools](https://github.com/LabForComputationalVision/pyrtools). Essentially it just gives back a low value for images that don't have a lot going on, and high value for 'busy' images.

The EmbedAnnotator essentially does the same as the shape feature in SEMIA, and for movement I'm not entirely sure how to implement it nicely so I'll open an issue about that.

I'd be happy to restructure / rename things etc, but figured this would be the most productive way to set things in motion.