### PR TITLE
Optical flow annotators

### DIFF
--- a/dvt/annotate/__init__.py
+++ b/dvt/annotate/__init__.py
@@ -7,8 +7,10 @@ from . import core
 from . import diff
 from . import embed
 from . import face
+from . import hofm
 from . import png
 from . import object
+from . import opticalflow
 from . import meta
 
 __version__ = "0.1.0"

--- a/dvt/annotate/hofm.py
+++ b/dvt/annotate/hofm.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Annotator to extract dense Optical Flow using the opencv 
+Gunnar Farneback’s algorithm and represent it as a 
+histogram of optical flow orientation and magnitude (HOFM),
+as described in https://doi.org/10.1109/SIBGRAPI.2015.21
+"""
+
+import numpy as np
+import cv2
+from skimage.util import view_as_blocks
+
+from .core import FrameAnnotator
+from ..utils import _proc_frame_list, _which_frames
+
+
+class HOFMAnnotator(FrameAnnotator):
+    """Annotator to extract dense Optical Flow using the opencv 
+    Gunnar Farneback’s algorithm and represent it as a 
+    histogram of optical flow orientation and magnitude (HOFM),
+    as described in https://doi.org/10.1109/SIBGRAPI.2015.21
+
+    The annotator will return the optical flow describing the motion in
+    two subsequent frames as a HOFM feature.
+
+    Attributes:
+        freq (int): How often to perform the embedding. For example, setting
+            the frequency to 2 will computer every other frame in the batch.
+        blocks (int): How many spatial blocks to divide the frame in, in each
+            dimension. Default is 3, which results in 9 spatial blocks.
+        mag_buckets (list of ints): List of bounds for magnitude
+            buckets. Default is [0, 20, 40, 60, 80, 100].
+        ang_buckets (list of ints): List of bounds for angle
+            buckets. Default is [0, 45, 90, 135, 180, 225, 270, 315, 360].
+        frames (array of ints): An optional list of frames to process. This
+            should be a list of integers or a 1D numpy array of integers. If set
+            to something other than None, the freq input is ignored.
+    """
+
+    name = "hofm"
+
+    def __init__(
+        self, freq=1, blocks=3, mag_buckets = [0, 20, 40, 60, 80, 100],
+        ang_buckets = [0, 45, 90, 135, 180, 225, 270, 315, 360], frames=None):
+
+        self.freq = freq
+        self.blocks = blocks
+        self.mag_buckets = mag_buckets
+        self.ang_buckets = ang_buckets
+        self.frames = _proc_frame_list(frames)
+        super().__init__()
+
+    def annotate(self, batch):
+        """Annotate the batch of frames with the optical flow annotator.
+
+        Args:
+            batch (FrameBatch): A batch of images to annotate.
+
+        Returns:
+            A list of dictionaries containing the video name, frame, and the
+            HOFM optical flow representation of length (len(blocks) *
+            len(blocks) * len(mag_buckets) * len(ang_buckets))
+        """
+        # determine which frames to work on
+        frames = _which_frames(batch, self.freq, self.frames)
+        if not frames:
+            return
+
+        # run the optical flow analysis on each frame
+        hofm = []
+        for fnum in frames:
+            current_gray = cv2.cvtColor(batch.img[fnum, :, :, :],
+                    cv2.COLOR_RGB2GRAY)
+            next_gray = cv2.cvtColor(batch.img[fnum+1, :, :, :],
+                    cv2.COLOR_RGB2GRAY)
+
+            flow = _get_optical_flow(current_gray, next_gray)
+
+            hofm.append(_make_block_hofm(flow, self.blocks,
+                self.mag_buckets, self.ang_buckets).flatten())
+
+        obj = {"hofm": np.stack(hofm)}
+
+        # Add video and frame metadata
+        obj["video"] = [batch.vname] * len(frames)
+        obj["frame"] = np.array(batch.get_frame_names())[list(frames)]
+
+        return [obj]
+
+
+def _get_optical_flow(current_frame, next_frame):
+
+    return cv2.calcOpticalFlowFarneback(current_frame, 
+                            next_frame, flow=None,
+                            pyr_scale=0.5, levels=1, winsize=15,
+                            iterations=2,
+                            poly_n=5, poly_sigma=1.1, flags=0)
+
+
+def _make_block_hofm(flow, blocks, mag_buckets, ang_buckets):
+    mag, ang = cv2.cartToPolar(flow[...,0], flow[...,1], angleInDegrees=True)
+
+    mag_digit = np.digitize(mag, mag_buckets)
+    # mod so 360 falls into first bucket
+    ang_digit = np.digitize(ang%360, ang_buckets) 
+    
+    mag_blocks = view_as_blocks(mag_digit, (blocks,blocks))
+    ang_blocks = view_as_blocks(ang_digit, (blocks,blocks))
+
+    histogram = np.zeros((blocks, blocks, len(mag_buckets), 
+        len(ang_buckets)-1))
+
+    for x in range(blocks):
+        for y in range(blocks):
+            for m,a in zip(mag_blocks[:,:,x,y].flatten(), 
+                    ang_blocks[:,:,x,y].flatten()):
+                histogram[x,y, m-1,a-1] += 1
+        # normalize by block size (h,w)
+        histogram[x,y,:,:] /= mag_blocks[:,:,x,y].size 
+    return histogram

--- a/dvt/annotate/opticalflow.py
+++ b/dvt/annotate/opticalflow.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Annotator to extract dense Optical Flow using the opencv 
+Gunnar Farneback’s algorithm.
+"""
+
+import numpy as np
+import cv2
+
+from .core import FrameAnnotator
+from ..utils import _proc_frame_list, _which_frames
+
+
+class OpticalFlowAnnotator(FrameAnnotator):
+    """Annotator to extract dense Optical Flow using the opencv Gunnar
+    Farneback’s algorithm.
+
+    The annotator will return an image or flow field describing the motion in
+    two subsequent frames.
+
+    Attributes:
+        freq (int): How often to perform the embedding. For example, setting
+            the frequency to 2 will computer every other frame in the batch.
+        raw (bool): Return optical flow as color image by default, raw returns
+        the raw output as produced by the opencv algorithm.
+        frames (array of ints): An optional list of frames to process. This
+            should be a list of integers or a 1D numpy array of integers. If set
+            to something other than None, the freq input is ignored.
+    """
+
+    name = "opticalflow"
+
+    def __init__(
+        self, freq=1, raw=False, frames=None
+    ):
+
+        self.freq = freq
+        self.raw = raw
+        self.frames = _proc_frame_list(frames)
+        super().__init__()
+
+    def annotate(self, batch):
+        """Annotate the batch of frames with the optical flow annotator.
+
+        Args:
+            batch (FrameBatch): A batch of images to annotate.
+
+        Returns:
+            A list of dictionaries containing the video name, frame, and the
+            optical flow representation. The latter has the same spatial
+            dimensions as the input.
+        """
+        # determine which frames to work on
+        frames = _which_frames(batch, self.freq, self.frames)
+        if not frames:
+            return
+
+        # run the optical flow analysis on each frame
+        flow = []
+        for fnum in frames:
+            current_gray = cv2.cvtColor(batch.img[fnum, :, :, :],
+                    cv2.COLOR_RGB2GRAY)
+            next_gray = cv2.cvtColor(batch.img[fnum+1, :, :, :],
+                    cv2.COLOR_RGB2GRAY)
+
+            flow += [_get_optical_flow(current_gray, next_gray)]
+
+            if not self.raw:
+                flow[-1] = _flow_to_color(
+                        flow[-1])
+
+        obj = {"opticalflow": np.stack(flow)}
+
+        # Add video and frame metadata
+        obj["video"] = [batch.vname] * len(frames)
+        obj["frame"] = np.array(batch.get_frame_names())[list(frames)]
+
+        return [obj]
+
+
+def _get_optical_flow(current_frame, next_frame):
+
+    return cv2.calcOpticalFlowFarneback(current_frame, 
+                            next_frame, flow=None,
+                            pyr_scale=0.5, levels=1, winsize=15,
+                            iterations=2,
+                            poly_n=5, poly_sigma=1.1, flags=0)
+
+# Optical flow to color image conversion code adapted from:
+# https://github.com/tomrunia/OpticalFlow_Visualization
+
+def _make_colorwheel():
+    """
+    Generates a color wheel for optical flow visualization as presented in:
+        Baker et al. "A Database and Evaluation Methodology for Optical Flow" (ICCV, 2007)
+        URL: http://vision.middlebury.edu/flow/flowEval-iccv07.pdf
+    According to the C++ source code of Daniel Scharstein
+    According to the Matlab source code of Deqing Sun
+    """
+
+    RY = 15
+    YG = 6
+    GC = 4
+    CB = 11
+    BM = 13
+    MR = 6
+
+    ncols = RY + YG + GC + CB + BM + MR
+    colorwheel = np.zeros((ncols, 3))
+    col = 0
+
+    # RY
+    colorwheel[0:RY, 0] = 255
+    colorwheel[0:RY, 1] = np.floor(255*np.arange(0,RY)/RY)
+    col = col+RY
+    # YG
+    colorwheel[col:col+YG, 0] = 255 - np.floor(255*np.arange(0,YG)/YG)
+    colorwheel[col:col+YG, 1] = 255
+    col = col+YG
+    # GC
+    colorwheel[col:col+GC, 1] = 255
+    colorwheel[col:col+GC, 2] = np.floor(255*np.arange(0,GC)/GC)
+    col = col+GC
+    # CB
+    colorwheel[col:col+CB, 1] = 255 - np.floor(255*np.arange(CB)/CB)
+    colorwheel[col:col+CB, 2] = 255
+    col = col+CB
+    # BM
+    colorwheel[col:col+BM, 2] = 255
+    colorwheel[col:col+BM, 0] = np.floor(255*np.arange(0,BM)/BM)
+    col = col+BM
+    # MR
+    colorwheel[col:col+MR, 2] = 255 - np.floor(255*np.arange(MR)/MR)
+    colorwheel[col:col+MR, 0] = 255
+    return colorwheel
+
+
+def _flow_compute_color(u, v):
+    """
+    Applies the flow color wheel to (possibly clipped) flow components u and v.
+    According to the C++ source code of Daniel Scharstein
+    According to the Matlab source code of Deqing Sun
+
+    Attributes:
+        u (np.ndarray): horizontal flow.
+        v (np.ndarray): vertical flow.
+    """
+
+    flow_image = np.zeros((u.shape[0], u.shape[1], 3), np.uint8)
+
+    colorwheel = _make_colorwheel()  # shape [55x3]
+    ncols = colorwheel.shape[0]
+
+    rad = np.sqrt(np.square(u) + np.square(v))
+    a = np.arctan2(-v, -u)/np.pi
+
+    fk = (a+1) / 2*(ncols-1)
+    k0 = np.floor(fk).astype(np.int32)
+    k1 = k0 + 1
+    k1[k1 == ncols] = 0
+    f = fk - k0
+
+    for i in range(colorwheel.shape[1]):
+
+        tmp = colorwheel[:,i]
+        col0 = tmp[k0] / 255.0
+        col1 = tmp[k1] / 255.0
+        col = (1-f)*col0 + f*col1
+
+        idx = (rad <= 1)
+        col[idx]  = 1 - rad[idx] * (1-col[idx])
+        col[~idx] = col[~idx] * 0.75   # out of range?
+
+        flow_image[:,:,i] = np.floor(255 * col)
+
+    return flow_image
+
+
+def _flow_to_color(flow_uv, clip_flow=None):
+    """
+    Expects a two dimensional flow image of shape [H,W,2]
+    According to the C++ source code of Daniel Scharstein
+    According to the Matlab source code of Deqing Sun
+
+    Attributes:
+        flow_uv (np.ndarray): np.ndarray of optical flow with shape [H,W,2] 
+        clip_flow (float): maximum clipping value for flow
+    """
+
+    assert flow_uv.ndim == 3, 'input flow must have three dimensions'
+    assert flow_uv.shape[2] == 2, 'input flow must have shape [H,W,2]'
+
+    if clip_flow is not None:
+        flow_uv = np.clip(flow_uv, 0, clip_flow)
+
+    u = flow_uv[:,:,0]
+    v = flow_uv[:,:,1]
+
+    rad = np.sqrt(np.square(u) + np.square(v))
+    rad_max = np.max(rad)
+
+    epsilon = 1e-5
+    u = u / (rad_max + epsilon)
+    v = v / (rad_max + epsilon)
+
+    return _flow_compute_color(u, v)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pandas
 keras
 tensorflow
 scipy>=1.0.0
+scikit-image
 h5py
 opencv-python
 keras_retinanet


### PR DESCRIPTION
Added two types of optical flow annotators, one which can do raw optical flow, but by default outputs colour images of the optical flow (using code from https://github.com/tomrunia/OpticalFlow_Visualization), which is useful for visualisation purposes. The raw output could be used for further analysis or processing.

Also added the Histogram of Optical Flow Orientation and Magnitude (HOFM) feature (https://doi.org/10.1109/SIBGRAPI.2015.21) annotator that we use in SEMIA, this creates a histogram based on spatial blocks and bins for different angle and magnitude values based on optical flow. 

The HOFM annotator relies on a single function from scikit-image now, I'll try to see if I can replace it in the future so the extra dependency isn't necessary.